### PR TITLE
Add missing use statements in test file

### DIFF
--- a/t/slang.t
+++ b/t/slang.t
@@ -3,6 +3,9 @@ use Test;
 plan 2;
 
 use BioInfo;
+use BioInfo::Parser::FASTA::Grammar;
+use BioInfo::Parser::FASTA::Actions;
+use BioInfo::Seq::DNA;
 
 {
     my $dnastr = " 


### PR DESCRIPTION
The design of Perl 6 requires that use statements only have effect in a
lexical scope. Otherwise it's impossible to use different (versions of)
modules sharing a name in different parts of a program.

This means essentially that we need to explicitly use all modules we need
in a scope.

See https://gist.github.com/niner/70f7b46eefb7e22af78d896bea11efeb for
further information.