### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,6 +1,7 @@
 {
     "perl" : "6.*",
     "name" : "BioInfo",
+    "license" : "Artistic-2.0",
     "version" : "0.4.3",
     "description" : "Bioinformatics modules written specifically for a Perl6 generation.",
     "author" : "Matt Oates",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license